### PR TITLE
Sales engine items initialize

### DIFF
--- a/lib/item_repo.rb
+++ b/lib/item_repo.rb
@@ -1,6 +1,6 @@
 require 'CSV'
-require './lib/cleaner'
-require './lib/item'
+require_relative './cleaner'
+require_relative './item'
 
 class ItemRepository
   attr_reader :items
@@ -8,9 +8,10 @@ class ItemRepository
   def initialize(file = './data/items.csv')
     @file = file
     @cleaner = Cleaner.new
-    @items_csv = @cleaner.open_csv(@file)
+    @items_csv = CSV.open(@file, headers: true, header_converters: :symbol)
     @items = []
     item_objects(@items_csv)
+
   end
 
   def item_objects(items)

--- a/lib/merchant_repo.rb
+++ b/lib/merchant_repo.rb
@@ -1,6 +1,6 @@
 require 'CSV'
-require './lib/cleaner.rb'
-require './lib/merchant.rb'
+require_relative './cleaner.rb'
+require_relative './merchant.rb'
 
 class MerchantRepository
   attr_accessor :merchants
@@ -17,10 +17,11 @@ class MerchantRepository
   def build_merchants
     @data.map do |merchant|
       cleaner = Cleaner.new
-      merch = Merchant.new({        id: cleaner.clean_id(merchant[:id]),
-                                  name: cleaner.clean_name(merchant[:name]),
-                            created_at: cleaner.clean_date(merchant[:created_at]),
-                            updated_at: cleaner.clean_date(merchant[:updated_at])}, self)
+      merch = Merchant.new({
+        id: cleaner.clean_id(merchant[:id]),
+        name: cleaner.clean_name(merchant[:name]),
+        created_at: cleaner.clean_date(merchant[:created_at]),
+        updated_at: cleaner.clean_date(merchant[:updated_at])}, self)
       @merchants << merch
       end
     @merchants

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -3,12 +3,12 @@ require_relative './item_repo'
 
 
 class SalesEngine
-  attr_reader :items
+  attr_reader :items,
+              :merchants
 
   def initialize(data)
-    @items = data[:items]
-    @merchant_repo = MerchantRepository.new(data[:merchants], self)
-    @item_repo = ItemRepository.new(data[:items])
+    @merchants = MerchantRepository.new(data[:merchants], self)
+    @items = ItemRepository.new(data[:items])
   end
 
   def self.from_csv(data)

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -14,8 +14,4 @@ class SalesEngine
   def self.from_csv(data)
     new(data)
   end
-
-  def merchants
-    @merchant_repo.build_merchants
-  end
 end

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -1,4 +1,5 @@
-require './lib/merchant_repo'
+require_relative './merchant_repo'
+require_relative './item_repo'
 
 
 class SalesEngine
@@ -6,8 +7,8 @@ class SalesEngine
 
   def initialize(data)
     @items = data[:items]
-    @file = data[:merchants]
-    @merchant_repo = MerchantRepository.new(@file, self)
+    @merchant_repo = MerchantRepository.new(data[:merchants], self)
+    @item_repo = ItemRepository.new(data[:items])
   end
 
   def self.from_csv(data)

--- a/test/sales_engine_test.rb
+++ b/test/sales_engine_test.rb
@@ -14,13 +14,9 @@ class SalesEngineTest < Minitest::Test
     assert_instance_of SalesEngine, @se
   end
 
-  # def test_it_has_readable_attributes
-  #   assert_equal "./data/items.csv", @se.items
-  #   assert_equal "./data/merchants.csv", @se.merchants
-  # end
-
   def test_sales_engine_can_build_merchant_repo
 
-    assert_equal 475, @se.merchants.count
+    assert_equal MerchantRepository, @se.merchants.class
+    assert_equal ItemRepository, @se.items.class
   end
 end


### PR DESCRIPTION
Taking Megan's feedback from yesterday, I cleaned up the open CSV file so it lives in the repos rather than the cleaner file. I refactored the initialize method in Sales engine so we do not need separate instance variables for each csv file