### PR TITLE
Move update to item

### DIFF
--- a/lib/item.rb
+++ b/lib/item.rb
@@ -11,16 +11,27 @@ class Item
               :merchant_id
 
   def initialize(data)
-    @id = data[:id]
-    @name = data[:name]
+    @id          = data[:id]
+    @name        = data[:name]
     @description = data[:description]
-    @unit_price = data[:unit_price]
-    @created_at = data[:created_at]
-    @updated_at = data[:updated_at]
+    @unit_price  = data[:unit_price]
+    @created_at  = data[:created_at]
+    @updated_at  = data[:updated_at]
     @merchant_id = data[:merchant_id]
   end
 
   def unit_price_to_dollars
     unit_price.round * 0.01
   end
+
+  def update(id, attributes)
+    item = find_item_by_id(id)
+    unless item.nil?
+      item[0].name        = attributes[:name] if attributes[:name]
+      item[0].description = attributes[:description] if attributes[:description]
+      item[0].unit_price  = attributes[:unit_price] if attributes[:unit_price]
+      item[0].updated_at  = Time.now
+    end
+  end
+
 end

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -24,14 +24,18 @@ class Item
     unit_price.round * 0.01
   end
 
-  def update(id, attributes)
-    item = find_item_by_id(id)
-    unless item.nil?
-      item[0].name        = attributes[:name] if attributes[:name]
-      item[0].description = attributes[:description] if attributes[:description]
-      item[0].unit_price  = attributes[:unit_price] if attributes[:unit_price]
-      item[0].updated_at  = Time.now
-    end
+  def update(attributes)
+    # item = find_item_by_id(id)
+    # unless item.nil?
+    # item[0].name        = attributes[:name] if attributes[:name]
+    # item[0].description = attributes[:description] if attributes[:description]
+    # item[0].unit_price  = attributes[:unit_price] if attributes[:unit_price]
+    # item[0].updated_at  = Time.now
+    # end
+    @name        = attributes[:name] if attributes[:name]
+    @description = attributes[:description] if attributes[:description]
+    @unit_price  = attributes[:unit_price] if attributes[:unit_price]
+    @updated_at  = Time.now
   end
 
 end

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -31,5 +31,4 @@ class Item
     @unit_price  = attributes[:unit_price] if attributes[:unit_price]
     @updated_at  = Time.now
   end
-
 end

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -2,13 +2,14 @@ require 'bigdecimal'
 require 'time'
 
 class Item
-  attr_accessor :id,
-              :name,
-              :description,
-              :unit_price,
+  attr_reader :id,
               :created_at,
-              :updated_at,
               :merchant_id
+
+  attr_accessor :name,
+                :description,
+                :unit_price,
+                :updated_at
 
   def initialize(data)
     @id          = data[:id]
@@ -25,13 +26,6 @@ class Item
   end
 
   def update(attributes)
-    # item = find_item_by_id(id)
-    # unless item.nil?
-    # item[0].name        = attributes[:name] if attributes[:name]
-    # item[0].description = attributes[:description] if attributes[:description]
-    # item[0].unit_price  = attributes[:unit_price] if attributes[:unit_price]
-    # item[0].updated_at  = Time.now
-    # end
     @name        = attributes[:name] if attributes[:name]
     @description = attributes[:description] if attributes[:description]
     @unit_price  = attributes[:unit_price] if attributes[:unit_price]

--- a/lib/item_repo.rb
+++ b/lib/item_repo.rb
@@ -94,6 +94,16 @@ class ItemRepository
     end
   end
 
+  # def update(id, attributes)
+    # item = find_item_by_id(id)
+    # unless item.nil?
+      # item[0].name        = attributes[:name] if attributes[:name]
+      # item[0].description = attributes[:description] if attributes[:description]
+      # item[0].unit_price  = attributes[:unit_price] if attributes[:unit_price]
+      # item[0].updated_at  = Time.now
+    # end
+  # end
+
   def delete(id)
     @items.delete(find_item_by_id(id)[0])
   end

--- a/lib/item_repo.rb
+++ b/lib/item_repo.rb
@@ -94,16 +94,6 @@ class ItemRepository
     end
   end
 
-  # def update(id, attributes)
-    # item = find_item_by_id(id)
-    # unless item.nil?
-      # item[0].name        = attributes[:name] if attributes[:name]
-      # item[0].description = attributes[:description] if attributes[:description]
-      # item[0].unit_price  = attributes[:unit_price] if attributes[:unit_price]
-      # item[0].updated_at  = Time.now
-    # end
-  # end
-
   def delete(id)
     @items.delete(find_item_by_id(id)[0])
   end

--- a/test/item_repo_test.rb
+++ b/test/item_repo_test.rb
@@ -96,38 +96,6 @@ class ItemRepositoryTest < Minitest::Test
     assert_equal 263395721, @item_repository.sort_by_id[2].id
   end
 
-
-  def test_update
-    attributes = {
-      name: "Capita Defenders of Awesome 2018",
-      description: "This board both rips and shreds",
-      unit_price: BigDecimal.new(399.99, 5),
-      created_at: Time.now,
-      updated_at: Time.now,
-      merchant_id: 25
-    }
-
-    updated_attribute_hash = {
-      :name => "Bleeps",
-      :description => "doop doop doop",
-      :unit_price => BigDecimal.new(599.99, 5)
-    }
-
-    # updated_time = mock()
-    # updated_time.stubs(:updated_at).returns(2021-01-07 18:03:23 -0700)
-
-    # allow(Time).to receive(:now).and_return(@time_now)
-
-    # Time.stubs(:now).returns(Time.mktime(1970,1,1))
-
-    @item_repository.create(attributes)
-    assert_equal 263567475, @item_repository.find_by_name("Capita Defenders of Awesome 2018").id
-    @item_repository.update(263567475, updated_attribute_hash)
-    assert_equal 263567475, @item_repository.find_by_name("Bleeps").id
-
-    #assert_equal mock_time, @item_repository.find_by_name("Bleeps").updated_at
-  end
-
   def test_it_deletes_items
     attributes = {
       name: "Capita Defenders of Awesome 2018",

--- a/test/item_test.rb
+++ b/test/item_test.rb
@@ -1,11 +1,12 @@
 require 'minitest/autorun'
 require 'minitest/pride'
+require 'mocha/minitest'
 require './lib/item'
 require './lib/cleaner'
-# refactor to mock/stubs to avoid redundancy?
+# refactor to mock/stubs or traverse vertically to not need to require IR?
 # But in the update test we do need to check on a real item i think?
 require './lib/item_repo'
-
+ 
 
 class ItemTest < Minitest::Test
   def setup
@@ -36,7 +37,7 @@ class ItemTest < Minitest::Test
     assert_equal 0.11, @item.unit_price_to_dollars
   end
 
-  def test_update
+  def test_it_updates_item_attributes
     ir = ItemRepository.new
 
     attributes = {
@@ -47,20 +48,32 @@ class ItemTest < Minitest::Test
       updated_at: Time.now,
       merchant_id: 25
     }
+
+    Time.stubs(:now).returns("Black Thursday")
+
     updated_attribute_hash = {
+      :id => 888444555,
       :name => "Bleeps",
       :description => "doop doop doop",
-      :unit_price => BigDecimal.new(599.99, 5)
+      :unit_price => BigDecimal.new(599.99, 5),
+      :created_at => Time.now,
+      :merchant_id => 46
     }
-    # updated_time = mock()
     # updated_time.stubs(:updated_at).returns(2021-01-07 18:03:23 -0700)
-    # allow(Time).to receive(:now).and_return(@time_now)
     # Time.stubs(:now).returns(Time.mktime(1970,1,1))
+
     ir.create(attributes)
-    target_item = ir.find_item_by_id(263567475)[0]
     require "pry"; binding.pry
-    target_item.update(263567475, updated_attribute_hash)
-    assert_equal 263567475, ir.find_by_name("Bleeps").id
+    target_item = ir.find_item_by_id(263567475)[0]
+    target_item.update(updated_attribute_hash)
+    # check attributes were updated
+    assert_equal "Bleeps", target_item.name
+    assert_equal "doop doop doop", target_item.description
+    assert_equal BigDecimal.new(599.99, 5), target_item.unit_price
+    # check permanent attributes are unchanged
+    assert_equal 263567475, target_item.id
+    assert_equal false, "Black Thursday" == target_item.created_at
+    assert_equal false, 46 == target_item.merchant_id
   end
 
 end

--- a/test/item_test.rb
+++ b/test/item_test.rb
@@ -4,9 +4,8 @@ require 'mocha/minitest'
 require './lib/item'
 require './lib/cleaner'
 # refactor to mock/stubs or traverse vertically to not need to require IR?
-# But in the update test we do need to check on a real item i think?
+# But in the update test we do need to check on a real item i think
 require './lib/item_repo'
-
 
 class ItemTest < Minitest::Test
   def setup

--- a/test/item_test.rb
+++ b/test/item_test.rb
@@ -52,11 +52,11 @@ class ItemTest < Minitest::Test
     Time.stubs(:now).returns("Black Thursday")
 
     updated_attribute_hash = {
-      :id => 888444555,
-      :name => "Bleeps",
+      :id          => 888444555,
+      :name        => "Bleeps",
       :description => "doop doop doop",
-      :unit_price => BigDecimal.new(599.99, 5),
-      :created_at => Time.now,
+      :unit_price  => BigDecimal.new(599.99, 5),
+      :created_at  => Time.now,
       :merchant_id => 46
     }
 
@@ -72,5 +72,4 @@ class ItemTest < Minitest::Test
     assert_equal false, "Black Thursday" == target_item.created_at
     assert_equal false, 46 == target_item.merchant_id
   end
-
 end

--- a/test/item_test.rb
+++ b/test/item_test.rb
@@ -6,7 +6,7 @@ require './lib/cleaner'
 # refactor to mock/stubs or traverse vertically to not need to require IR?
 # But in the update test we do need to check on a real item i think?
 require './lib/item_repo'
- 
+
 
 class ItemTest < Minitest::Test
   def setup
@@ -59,11 +59,8 @@ class ItemTest < Minitest::Test
       :created_at => Time.now,
       :merchant_id => 46
     }
-    # updated_time.stubs(:updated_at).returns(2021-01-07 18:03:23 -0700)
-    # Time.stubs(:now).returns(Time.mktime(1970,1,1))
 
     ir.create(attributes)
-    require "pry"; binding.pry
     target_item = ir.find_item_by_id(263567475)[0]
     target_item.update(updated_attribute_hash)
     # check attributes were updated

--- a/test/item_test.rb
+++ b/test/item_test.rb
@@ -2,6 +2,10 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/item'
 require './lib/cleaner'
+# refactor to mock/stubs to avoid redundancy?
+# But in the update test we do need to check on a real item i think?
+require './lib/item_repo'
+
 
 class ItemTest < Minitest::Test
   def setup
@@ -14,7 +18,7 @@ class ItemTest < Minitest::Test
       :updated_at  => 12,
       :merchant_id => 2
       })
-      @cleaner = Cleaner.new
+      @cleaner = Cleaner.new # refactor out?
   end
 
   def test_it_exists_with_attributes
@@ -27,10 +31,36 @@ class ItemTest < Minitest::Test
     assert_equal 12, @item.updated_at
     assert_equal 2, @item.merchant_id
   end
-  
+
   def test_unit_price_to_dollars
     assert_equal 0.11, @item.unit_price_to_dollars
   end
 
-  
+  def test_update
+    ir = ItemRepository.new
+
+    attributes = {
+      name: "Capita Defenders of Awesome 2018",
+      description: "This board both rips and shreds",
+      unit_price: BigDecimal.new(399.99, 5),
+      created_at: Time.now,
+      updated_at: Time.now,
+      merchant_id: 25
+    }
+    updated_attribute_hash = {
+      :name => "Bleeps",
+      :description => "doop doop doop",
+      :unit_price => BigDecimal.new(599.99, 5)
+    }
+    # updated_time = mock()
+    # updated_time.stubs(:updated_at).returns(2021-01-07 18:03:23 -0700)
+    # allow(Time).to receive(:now).and_return(@time_now)
+    # Time.stubs(:now).returns(Time.mktime(1970,1,1))
+    ir.create(attributes)
+    target_item = ir.find_item_by_id(263567475)[0]
+    require "pry"; binding.pry
+    target_item.update(263567475, updated_attribute_hash)
+    assert_equal 263567475, ir.find_by_name("Bleeps").id
+  end
+
 end


### PR DESCRIPTION
## Item / Item Repo
* I transplanted `#update` from ItemRepository to Item. 
* I changed attr_x exposure to block changes to permanent attributes. 

## Item Tests
* I required `item_repository` to access `create` method. This could be reworked with either mocks and stubs, or with a vertical traverse
* I moved our `update` test from ItemRepoTest, but I basically rewrote most of the assertions
* I added a stubs method to Time to make test `created_at` can't be updated. 
* I added additional test assertions reflecting the spec harness tests. 