### PR TITLE
Items and ItemRepo - BigDecimal matches spec

### DIFF
--- a/lib/item.rb
+++ b/lib/item.rb
@@ -22,7 +22,7 @@ class Item
   end
 
   def unit_price_to_dollars
-    @unit_price.round * 0.01
+    @unit_price.to_f
   end
 
   def update(attributes)

--- a/lib/item_repo.rb
+++ b/lib/item_repo.rb
@@ -20,10 +20,12 @@ class ItemRepository
 
   def item_objects(items)
     items.each do |item|
+      precision      = item[:unit_price].length
+      value_adjusted = item[:unit_price].to_i * 0.01
       @items << Item.new({:id => item[:id].to_i,
                 :name        => item[:name],
                 :description => item[:description],
-                :unit_price  => BigDecimal.new(item[:unit_price]),
+                :unit_price  => BigDecimal.new(value_adjusted, precision),
                 :created_at  => @cleaner.clean_date(item[:created_at]),
                 :updated_at  => @cleaner.clean_date(item[:updated_at]),
                 :merchant_id => item[:merchant_id].to_i})

--- a/test/item_repo_test.rb
+++ b/test/item_repo_test.rb
@@ -119,10 +119,13 @@ class ItemRepositoryTest < Minitest::Test
     assert_equal 263567475, @item_repository.find_by_name("Capita Defenders of Awesome 2018").id
 
     @item_repository.update(263567475, updated_attribute_hash)
+    # check desired attributes were updated
     assert_equal 263567475, @item_repository.find_by_name("Bleeps").id
     item = @item_repository.find_by_name("Bleeps")
     assert item.updated_at == 46
     assert_equal "doop doop doop", item.description
+    # check fixed attributes are unchanged
+    assert_equal 263567475, @item_repository.find_by_name("Bleeps").id
   end
 
   def test_it_deletes_items

--- a/test/item_repo_test.rb
+++ b/test/item_repo_test.rb
@@ -97,6 +97,8 @@ class ItemRepositoryTest < Minitest::Test
   end
 
   def test_update
+
+
     attributes = {
       name: "Capita Defenders of Awesome 2018",
       description: "This board both rips and shreds",
@@ -106,24 +108,21 @@ class ItemRepositoryTest < Minitest::Test
       merchant_id: 25
     }
 
+    Time.stubs(:now).returns(46)
     updated_attribute_hash = {
       :name => "Bleeps",
       :description => "doop doop doop",
       :unit_price => BigDecimal.new(599.99, 5)
     }
 
-    # updated_time = mock()
-    # updated_time.stubs(:updated_at).returns(2021-01-07 18:03:23 -0700)
-    # allow(Time).to receive(:now).and_return(@time_now)
-    # Time.stubs(:now).returns(Time.mktime(1970,1,1))
-
     @item_repository.create(attributes)
     assert_equal 263567475, @item_repository.find_by_name("Capita Defenders of Awesome 2018").id
 
     @item_repository.update(263567475, updated_attribute_hash)
     assert_equal 263567475, @item_repository.find_by_name("Bleeps").id
-
-    #assert_equal mock_time, @item_repository.find_by_name("Bleeps").updated_at
+    item = @item_repository.find_by_name("Bleeps")
+    assert item.updated_at == 46
+    assert_equal "doop doop doop", item.description
   end
 
   def test_it_deletes_items

--- a/test/item_repo_test.rb
+++ b/test/item_repo_test.rb
@@ -96,7 +96,6 @@ class ItemRepositoryTest < Minitest::Test
     assert_equal 263395721, @item_repository.sort_by_id[2].id
   end
 
-
   def test_update
     attributes = {
       name: "Capita Defenders of Awesome 2018",

--- a/test/item_test.rb
+++ b/test/item_test.rb
@@ -25,6 +25,7 @@ class ItemTest < Minitest::Test
     assert_equal "Pencil", @item.name
     assert_equal "You can use it to write things", @item.description
     assert_equal 10.99, @item.unit_price
+    assert_equal BigDecimal, @item.unit_price.class
     assert_equal 10, @item.created_at
     assert_equal 12, @item.updated_at
     assert_equal 2, @item.merchant_id

--- a/test/item_test.rb
+++ b/test/item_test.rb
@@ -3,8 +3,6 @@ require 'minitest/pride'
 require 'mocha/minitest'
 require './lib/item'
 require './lib/cleaner'
-# refactor to mock/stubs or traverse vertically to not need to require IR?
-# But in the update test we do need to check on a real item i think
 require './lib/item_repo'
 
 class ItemTest < Minitest::Test
@@ -18,7 +16,7 @@ class ItemTest < Minitest::Test
       :updated_at  => 12,
       :merchant_id => 2
       })
-      @cleaner = Cleaner.new # refactor out?
+      @cleaner = Cleaner.new
   end
 
   def test_it_exists_with_attributes
@@ -26,14 +24,14 @@ class ItemTest < Minitest::Test
     assert_equal 1, @item.id
     assert_equal "Pencil", @item.name
     assert_equal "You can use it to write things", @item.description
-    assert_equal 0.1099e2, @item.unit_price
+    assert_equal 10.99, @item.unit_price
     assert_equal 10, @item.created_at
     assert_equal 12, @item.updated_at
     assert_equal 2, @item.merchant_id
   end
 
   def test_unit_price_to_dollars
-    assert_equal 0.11, @item.unit_price_to_dollars
+    assert_equal 10.99, @item.unit_price_to_dollars
   end
 
   def test_it_updates_item_attributes


### PR DESCRIPTION
## Item
* Changed price_to_dollars to reflect that value adjustment is made on creation, only needs to return a float

## Item Test
* Fix test expectations to reflect bigdecimal rework
* Add assertion for BigDecimal data type, match spec harness pattern

## ItemRepo
* Add holders for precision and adjust value, to reflect spec harness pattern of data transformation

## ItemRepoTest
* Cleanup leftover comment lines, rebuild Time stub to test that updated_at gets updated by update method

