### PR TITLE
Rework test files to run simplecov

### DIFF
--- a/test/cleaner_test.rb
+++ b/test/cleaner_test.rb
@@ -1,5 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
+require './test/test_helper'
 require './lib/cleaner'
 
 class CleanerTest < MiniTest::Test

--- a/test/customer_repo_test.rb
+++ b/test/customer_repo_test.rb
@@ -1,6 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
-require 'mocha/minitest'
+require './test/test_helper'
 require 'pry'
 require './lib/customer_repo'
 

--- a/test/customer_test.rb
+++ b/test/customer_test.rb
@@ -1,6 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
-require 'mocha/minitest'
+require './test/test_helper'
 require './lib/customer'
 
 class CustomerTest < MiniTest::Test

--- a/test/invoice_item_repo_test.rb
+++ b/test/invoice_item_repo_test.rb
@@ -1,5 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
+require './test/test_helper'
 require './lib/invoice_item_repo'
 
 class InvoiceItemRepo < Minitest::Test

--- a/test/invoice_item_test.rb
+++ b/test/invoice_item_test.rb
@@ -1,5 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
+require './test/test_helper'
 require './lib/invoice_item'
 
 class InvoiceItemTest < Minitest::Test

--- a/test/invoice_repo_test.rb
+++ b/test/invoice_repo_test.rb
@@ -1,8 +1,6 @@
-require 'minitest/autorun'
-require 'minitest/pride'
+require './test/test_helper'
 require './lib/invoice_repo'
 require './lib/sales_engine'
-
 require './lib/cleaner'
 require './lib/sales_engine'
 

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -1,5 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
+require './test/test_helper'
 require './lib/invoice'
 
 

--- a/test/item_repo_test.rb
+++ b/test/item_repo_test.rb
@@ -1,8 +1,6 @@
-require 'minitest/autorun'
-require 'minitest/pride'
+require './test/test_helper'
 require './lib/item_repo'
 require './lib/cleaner'
-require 'mocha/minitest'
 
 class ItemRepositoryTest < Minitest::Test
 

--- a/test/item_test.rb
+++ b/test/item_test.rb
@@ -1,6 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
-require 'mocha/minitest'
+require './test/test_helper'
 require './lib/item'
 require './lib/cleaner'
 require './lib/item_repo'

--- a/test/merchant_repo_test.rb
+++ b/test/merchant_repo_test.rb
@@ -1,5 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
+require './test/test_helper'
 require './lib/merchant_repo'
 
 class MerchantRepositoryTest < MiniTest::Test

--- a/test/merchant_test.rb
+++ b/test/merchant_test.rb
@@ -1,5 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
+require './test/test_helper'
 require './lib/merchant'
 
 class MerchantTest < MiniTest::Test

--- a/test/sales_analyst_test.rb
+++ b/test/sales_analyst_test.rb
@@ -1,21 +1,22 @@
-require 'minitest/autorun'
-require 'minitest/pride'
+require './test/test_helper'
 require './lib/sales_analyst'
 require './lib/sales_engine'
-
 class TestSalesAnalyst < MiniTest::Test
 
   def setup
     @sales_engine = SalesEngine.from_csv({
       items:      "./data/items.csv",
       merchants:  "./data/merchants.csv",
-      invoices:   "./data/invoices.csv"
+      invoices:   "./data/invoices.csv",
+      transactions: "./data/transactions.csv"
       })
     @sales_analyst = SalesAnalyst.new(@sales_engine)
   end
 
   def test_it_exists
     assert_instance_of SalesAnalyst, @sales_analyst
+    assert_equal SalesEngine, @sales_engine
+    assert_equal @sales_engine, @sales_analyst.sales_engine
   end
 
   def test_it_finds_average_items_per_merchant
@@ -53,7 +54,7 @@ class TestSalesAnalyst < MiniTest::Test
     assert_equal 10.49, @sales_analyst.average_invoices_per_merchant
     assert_equal Float, @sales_analyst.average_invoices_per_merchant.class
   end
-  #
+
   def test_invoice_standard_dev
     assert_equal 3.29, @sales_analyst.average_invoices_per_merchant_standard_deviation
   end
@@ -95,6 +96,7 @@ class TestSalesAnalyst < MiniTest::Test
 
   def test_merchants_with_pending_invoices
     assert_equal 467, @sales_analyst.merchants_with_pending_invoices.count
+  end
 
   def test_it_finds_merchants_with_only_one_item
     assert_equal 243, @sales_analyst.merchants_with_only_one_item.length
@@ -105,4 +107,11 @@ class TestSalesAnalyst < MiniTest::Test
     assert_equal 18, @sales_analyst.merchants_with_only_one_item_registered_in_month("June").length
     assert_equal Merchant, @sales_analyst.merchants_with_only_one_item_registered_in_month("June").first.class
   end
+
+  # def test_it_returns_revenue_for_given_merchant
+  #   expected = @sales_analyst.revenue_by_merchant(12334194)
+
+  #   assert_equal BigDecimal.new(expected), expected
+  #   assert_equal BigDecimal, expected
+  # end
 end

--- a/test/sales_engine_test.rb
+++ b/test/sales_engine_test.rb
@@ -1,5 +1,4 @@
-require 'Minitest/autorun'
-require 'Minitest/pride'
+require './test/test_helper'
 require './lib/sales_engine'
 
 class SalesEngineTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,11 @@
 require 'simplecov'
 SimpleCov.start
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'mocha/minitest'
 
-if ENV['RAILS_ENV'] == 'test'
-  require 'simplecov'
-  SimpleCov.start 'rails'
-  puts "required simplecov"
-end
+# if ENV['RAILS_ENV'] == 'test'
+#   require 'simplecov'
+#   SimpleCov.start 'rails'
+#   puts "required simplecov"
+# end

--- a/test/transaction_repo_test.rb
+++ b/test/transaction_repo_test.rb
@@ -1,8 +1,6 @@
-require 'minitest/autorun'
-require 'minitest/pride'
-require 'mocha/minitest'
 require 'pry'
 require 'CSV'
+require './test/test_helper'
 require './lib/transaction_repo'
 
 

--- a/test/transaction_test.rb
+++ b/test/transaction_test.rb
@@ -1,6 +1,4 @@
-require 'minitest/autorun'
-require 'minitest/pride'
-require 'mocha/minitest'
+require './test/test_helper'
 require 'pry'
 require './lib/transaction'
 


### PR DESCRIPTION
I changed the require methods in test files so that simple cov works properly and now we can just run the rake file and it generates a coverage report. Super handy and the coverage is actually like 97%. The rake file aborted for some reason but I'm sure we can figure that out pretty quickly. I'm happy to show everyone how this works before the merge.